### PR TITLE
fix(utils): Fix download_release to work on MacOS

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -42,7 +42,7 @@ download_release() {
   uname_m="$(uname -m)"
 
   case "$uname_s" in
-    Darwin) os="Darwin" ;;
+    Darwin) os="macos" ;;
     Linux) os="Linux" ;;
     *) fail "OS not supported: $uname_s" ;;
   esac
@@ -54,12 +54,6 @@ download_release() {
     arm64) arch="arm64" ;;
     *) fail "Architecture not supported: $uname_m" ;;
   esac
-
-  # Ugly hack until native M1 arm64 binaries are avaliable for Darwin from hadolint
-  # M1 chips can still run x86_64 binaries fine via Rosetta 2 in the meantime
-  if [[ $os == "Darwin" ]]; then
-    arch="x86_64"
-  fi
 
   url="$GH_REPO/releases/download/v${version}/hadolint-${os}-${arch}"
 


### PR DESCRIPTION
## Rationale

I recently tried using `asdf-hadolint` to install Hadolint on Mac=, but I got an error:

```shell
* Downloading hadolint release 2.14.0...
curl: (56) The requested URL returned error: 404
asdf-hadolint: Could not download https://github.com/hadolint/hadolint/releases/download/v2.14.0/hadolint-Darwin-x86_64
error installing version: failed to run download callback: exit status 1
```

Looking at hadolint's releases (https://github.com/hadolint/hadolint/releases), it appears we should use `macos` instead of `Darwin`. It also now supports ARM.

## Testing

```shell
% ASDF_DOWNLOAD_PATH=/tmp TOOL_NAME=hadolint ASDF_INSTALL_VERSION=2.14.0 ./bin/download
* Downloading hadolint release 2.14.0...
% ls /tmp/hadolint 
/tmp/hadolint
% /tmp/hadolint --version
Haskell Dockerfile Linter 2.14.0
```